### PR TITLE
Fixed integer overflow when calculating TSC frequency

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1037,7 +1037,7 @@ static void handle_std_tsc(struct cpu_regs_t *regs, struct cpuid_state_t *state)
 		printf("  TSC to core crystal clock ratio: %u / %d\n", regs->ebx, regs->eax);
 
 	if (regs->eax && regs->ebx && regs->ecx)
-		printf("  TSC frequency: %u MHz\n", (regs->ecx * regs->ebx / regs->eax) / 1000000);
+		printf("  TSC frequency: %lu Hz\n", (uint64_t)regs->ecx * regs->ebx / regs->eax);
 
 	printf("\n");
 }


### PR DESCRIPTION
Got wrong frequency due to overflow on Intel Atom E3940.

I changed the output to Hz as well since I didn't really see the point of not having it more exact.
But up to you I guess :)