### PR TITLE
Add detection for bhyve hypervisor

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1641,6 +1641,9 @@ static void handle_vmm_base(struct cpu_regs_t *regs, struct cpuid_state_t *state
 	} else if (strcmp(buf, " lrpepyh  vr") == 0) {
 		state->vendor |= VENDOR_HV_PARALLELS;
 		printf("Parallels Desktop detected\n\n");
+	} else if (strcmp(buf, "bhyve bhyve ") == 0) {
+		state->vendor |= VENDOR_HV_BHYVE;
+		printf("BHYVE hypervisor detected\n\n");
 	}
 }
 

--- a/vendor.h
+++ b/vendor.h
@@ -34,6 +34,7 @@ typedef enum
 	VENDOR_HV_KVM       = 0x40,
 	VENDOR_HV_HYPERV    = 0x80,
 	VENDOR_HV_PARALLELS = 0x100,
+	VENDOR_HV_BHYVE     = 0x200,
 	VENDOR_ANY          = (int)-1
 } cpu_vendor_t;
 


### PR DESCRIPTION
I'm not completely happy with the patch required to run_cpuid() but, like KVM, bhyve has two invalid request mappings however anything between 0x40000000 and 0x80000000 is mapped to 0x40000000 which fetches the hypervisor vendor.

It would be better to link this to the detection of the hypervisor bit in ECX.

With this patch:

```
# ./cpuid | grep -i hyp
  RAZ (hypervisor)
Maximum hypervisor CPUID leaf: 0x40000000
Hypervisor vendor string: 'bhyve bhyve '
BHYVE hypervisor detected
```

See https://github.com/omniosorg/illumos-omnios/blob/master/usr/src/uts/i86pc/io/vmm/x86.c#L112 for bhyve code that maps the invalid requests.