### PR TITLE
Add L1D Flush detection

### DIFF
--- a/feature.c
+++ b/feature.c
@@ -288,7 +288,7 @@ static const struct cpu_feature_t features [] = {
 /*	{ 0x00000007, 0, REG_EDX, 0x02000000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
 	{ 0x00000007, 0, REG_EDX, 0x04000000, VENDOR_INTEL                                , "Speculation Control (IBRS and IBPB)"},
 	{ 0x00000007, 0, REG_EDX, 0x08000000, VENDOR_INTEL                                , "Single Thread Indirect Branch Predictors (STIBP)"},
-/*	{ 0x00000007, 0, REG_EDX, 0x10000000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
+	{ 0x00000007, 0, REG_EDX, 0x10000000, VENDOR_INTEL                                , "L1 Data Cache (L1D) Flush"},
 	{ 0x00000007, 0, REG_EDX, 0x20000000, VENDOR_INTEL                                , "IA32_ARCH_CAPABILITIES MSR"},
 /*	{ 0x00000007, 0, REG_EDX, 0x40000000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
 	{ 0x00000007, 0, REG_EDX, 0x80000000, VENDOR_INTEL                                , "Speculative Store Bypass Disable (SSBD)"},


### PR DESCRIPTION
With updated CPU microcode, the new flag is properly reported.

```
Structured extended feature flags (ecx=0), edx:
  Speculation Control (IBRS and IBPB)
  Single Thread Indirect Branch Predictors (STIBP)
  L1 Data Cache (L1D) Flush
  Speculative Store Bypass Disable (SSBD)
```

versus before:

```
Unaccounted for in 0x00000007:0x00000000:
  eax: 0x00000000 ebx:0x00000000 ecx:0x00000000 edx:0x10000000
```

Reference: https://software.intel.com/security-software-guidance/api-app/sites/default/files/336996-Speculative-Execution-Side-Channel-Mitigations.pdf