### PR TITLE
Add Windows XP/2003 Server/Vista compatibility

### DIFF
--- a/msvc/CPUID.vcxproj
+++ b/msvc/CPUID.vcxproj
@@ -26,24 +26,24 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/prefix.h
+++ b/prefix.h
@@ -31,7 +31,7 @@
 #endif
 
 #ifdef TARGET_OS_WINDOWS
-#define _WIN32_WINNT 0x0601
+#define _WIN32_WINNT _WIN32_WINNT_WINXP
 #endif
 
 #include <assert.h>

--- a/util.c
+++ b/util.c
@@ -21,6 +21,8 @@
 
 #include "prefix.h"
 
+#include "util.h"
+
 #include <ctype.h>
 #include <limits.h>
 #include <string.h>
@@ -29,8 +31,6 @@
 #else
 #include <sys/time.h>
 #endif
-
-#include "util.h"
 
 size_t safe_strcat(char *dst, const char *src, size_t siz)
 {
@@ -118,11 +118,10 @@ double time_sec(void)
 #endif
 }
 
-BOOL IsWindows7OrGreater()
-{
-	BOOL bW7 = FALSE;
-	HMODULE hKernel32 = NULL;
+#ifdef TARGET_OS_WINDOWS
 
+BOOL is_windows7_or_greater()
+{
 	OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
 	DWORDLONG const dwlConditionMask = VerSetConditionMask(
 		VerSetConditionMask(
@@ -135,15 +134,7 @@ BOOL IsWindows7OrGreater()
 	osvi.dwMinorVersion = LOBYTE(_WIN32_WINNT_WIN7);
 	osvi.wServicePackMajor = 0;
 
-	bW7 = VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
-
-	if (bW7 && !pGetActiveProcessorGroupCount)
-	{
-		hKernel32 = GetModuleHandle(L"kernel32.dll");
-		pGetActiveProcessorGroupCount = (fnGetActiveProcessorGroupCount)(GetProcAddress(hKernel32, "GetActiveProcessorGroupCount"));
-		pGetActiveProcessorCount = (fnGetActiveProcessorCount)(GetProcAddress(hKernel32, "GetActiveProcessorCount"));
-		pSetThreadGroupAffinity = (fnSetThreadGroupAffinity)(GetProcAddress(hKernel32, "SetThreadGroupAffinity"));
-	}
-
-	return bW7;
+	return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
 }
+
+#endif

--- a/util.c
+++ b/util.c
@@ -21,8 +21,6 @@
 
 #include "prefix.h"
 
-#include "util.h"
-
 #include <ctype.h>
 #include <limits.h>
 #include <string.h>
@@ -31,6 +29,8 @@
 #else
 #include <sys/time.h>
 #endif
+
+#include "util.h"
 
 size_t safe_strcat(char *dst, const char *src, size_t siz)
 {

--- a/util.c
+++ b/util.c
@@ -117,3 +117,33 @@ double time_sec(void)
 	return (double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0);
 #endif
 }
+
+BOOL IsWindows7OrGreater()
+{
+	BOOL bW7 = FALSE;
+	HMODULE hKernel32 = NULL;
+
+	OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+	DWORDLONG const dwlConditionMask = VerSetConditionMask(
+		VerSetConditionMask(
+			VerSetConditionMask(
+				0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+			VER_MINORVERSION, VER_GREATER_EQUAL),
+		VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+
+	osvi.dwMajorVersion = HIBYTE(_WIN32_WINNT_WIN7);
+	osvi.dwMinorVersion = LOBYTE(_WIN32_WINNT_WIN7);
+	osvi.wServicePackMajor = 0;
+
+	bW7 = VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
+
+	if (bW7 && !pGetActiveProcessorGroupCount)
+	{
+		hKernel32 = GetModuleHandle(L"kernel32.dll");
+		pGetActiveProcessorGroupCount = (fnGetActiveProcessorGroupCount)(GetProcAddress(hKernel32, "GetActiveProcessorGroupCount"));
+		pGetActiveProcessorCount = (fnGetActiveProcessorCount)(GetProcAddress(hKernel32, "GetActiveProcessorCount"));
+		pSetThreadGroupAffinity = (fnSetThreadGroupAffinity)(GetProcAddress(hKernel32, "SetThreadGroupAffinity"));
+	}
+
+	return bW7;
+}

--- a/util.h
+++ b/util.h
@@ -31,17 +31,7 @@ double time_sec(void);
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))
 
 #ifdef TARGET_OS_WINDOWS
-
-typedef WORD(WINAPI *fnGetActiveProcessorGroupCount)();
-typedef DWORD(WINAPI *fnGetActiveProcessorCount)(WORD);
-typedef BOOL(WINAPI *fnSetThreadGroupAffinity)(HANDLE, const GROUP_AFFINITY *, PGROUP_AFFINITY);
-
-fnGetActiveProcessorGroupCount pGetActiveProcessorGroupCount;
-fnGetActiveProcessorCount pGetActiveProcessorCount;
-fnSetThreadGroupAffinity pSetThreadGroupAffinity;
-
-BOOL IsWindows7OrGreater();
-
+BOOL is_windows7_or_greater();
 #endif
 
 #endif

--- a/util.h
+++ b/util.h
@@ -30,4 +30,18 @@ double time_sec(void);
 
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))
 
+#ifdef TARGET_OS_WINDOWS
+
+typedef WORD(WINAPI *fnGetActiveProcessorGroupCount)();
+typedef DWORD(WINAPI *fnGetActiveProcessorCount)(WORD);
+typedef BOOL(WINAPI *fnSetThreadGroupAffinity)(HANDLE, const GROUP_AFFINITY *, PGROUP_AFFINITY);
+
+fnGetActiveProcessorGroupCount pGetActiveProcessorGroupCount;
+fnGetActiveProcessorCount pGetActiveProcessorCount;
+fnSetThreadGroupAffinity pSetThreadGroupAffinity;
+
+BOOL IsWindows7OrGreater();
+
+#endif
+
 #endif


### PR DESCRIPTION
Previously if you'd want to support mentioned Windows versions, you had to modify the _WIN32_WINNT constant in the prefix.h file. What is worse: the resulting program would not support modern API (e.g. GetActiveProcessorGroupCount) when running on Windows 7 and later.