### PR TITLE
Add TSX Force Abort MSR

### DIFF
--- a/feature.c
+++ b/feature.c
@@ -273,7 +273,7 @@ static const struct cpu_feature_t features [] = {
 	{ 0x00000007, 0, REG_EDX, 0x00000400, VENDOR_INTEL                                , "MD_CLEAR"},
 /*	{ 0x00000007, 0, REG_EDX, 0x00000800, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
 /*	{ 0x00000007, 0, REG_EDX, 0x00001000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
-/*	{ 0x00000007, 0, REG_EDX, 0x00002000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
+	{ 0x00000007, 0, REG_EDX, 0x00002000, VENDOR_INTEL                                , "TSX Force Abort MSR"},
 /*	{ 0x00000007, 0, REG_EDX, 0x00004000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
 	{ 0x00000007, 0, REG_EDX, 0x00008000, VENDOR_INTEL                                , "Hybrid"},
 /*	{ 0x00000007, 0, REG_EDX, 0x00010000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */


### PR DESCRIPTION
Only present in some older systems with update microcode, and not listed in the
official documention. However this is supported by Linux, Xen etc. so still
seems useful to report.

Signed-off-by: John Levon <levon@movementarian.org>