### PR TITLE
Fix detection of Hyper-V compliant hypervisors

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -279,6 +279,10 @@ static void handle_features(struct cpu_regs_t *regs, struct cpuid_state_t *state
 			model += (model == 0xf ? state->sig.extmodel << 4 : 0);
 		}
 
+		if (regs->ecx & (1 << 31)) {
+			state->vendor |= VENDOR_HV_GENERIC;
+		}
+
 		printf("Signature:  0x%08x\n"
 		       "  Family:   0x%02x (%d)\n"
 		       "  Model:    0x%02x (%d)\n"
@@ -1704,6 +1708,10 @@ static void handle_vmm_leaf01(struct cpu_regs_t *regs, struct cpuid_state_t *sta
 		buf[4] = 0;
 		*(uint32_t *)(&buf[0]) = regs->eax;
 		printf("Hypervisor interface identification: '%s'\n\n", buf);
+	} else if (state->vendor & VENDOR_HV_GENERIC
+			&& regs->eax == 0x31237648 /* "Hv#1" */) {
+		state->vendor |= VENDOR_HV_HYPERV;
+		printf("Hyper-V compliant hypervisor detected\n\n");
 	}
 }
 

--- a/vendor.h
+++ b/vendor.h
@@ -35,6 +35,7 @@ typedef enum
 	VENDOR_HV_HYPERV    = 0x80,
 	VENDOR_HV_PARALLELS = 0x100,
 	VENDOR_HV_BHYVE     = 0x200,
+	VENDOR_HV_GENERIC   = 0x400,
 	VENDOR_ANY          = (int)-1
 } cpu_vendor_t;
 


### PR DESCRIPTION
In some cases the hypervisor vendor string is nonstandard. Let's follow the hyperv-tlfs specification more closely to detect compliant hypervisors.