### PR TITLE
Print C[5-7]'s substates

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -649,8 +649,7 @@ static void handle_std_monitor(struct cpu_regs_t *regs, struct cpuid_state_t *st
 		unsigned reserved:20;
 	};
 	struct edx_monitor_t {
-		unsigned c:20;
-		unsigned reserved:12;
+		unsigned c:32;
 	};
 	unsigned int i;
 	struct eax_monitor_t *eax = (struct eax_monitor_t *)&regs->eax;


### PR DESCRIPTION
 Support CPUID 05H %edx bit 20-31 to print C5, C6 and C7's substates.