### PR TITLE
Handle gaps in XSAVE/XRSTOR feature mask

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -989,6 +989,7 @@ static const char *xsave_feature_name(uint32_t bit)
 static void handle_std_ext_state(struct cpu_regs_t *regs, struct cpuid_state_t *state)
 {
 	int i, j, max = 0;
+	uint64_t feature_mask = 0;
 
 	if ((state->vendor & (VENDOR_INTEL | VENDOR_AMD)) == 0)
 		return;
@@ -1054,7 +1055,9 @@ static void handle_std_ext_state(struct cpu_regs_t *regs, struct cpuid_state_t *
 			printf("  Maximum size required for all supported features: %3d bytes\n",
 				regs->ecx);
 
-			max = popcnt(regs->eax) + popcnt(regs->edx) - 1;
+			// eax is checked to be non-zero above, so at least one bit is set
+			feature_mask = (uint64_t)regs->edx << 32 | (uint64_t)regs->eax;
+			max = bit_scan_reverse(feature_mask);
 			printf("\n");
 		}
 	}

--- a/util.c
+++ b/util.c
@@ -84,6 +84,19 @@ uint32_t count_trailing_zero_bits(uint32_t v)
 	return c;
 }
 
+uint32_t bit_scan_reverse(uint64_t v) {
+	uint32_t c;
+
+	for (c = CHAR_BIT * sizeof(v) - 1; c > 0; c--) {
+		if (v & 0x80000000) {
+			break;
+		}
+		v <<= 1;
+	}
+
+	return c;
+}
+
 void squeeze(char *str)
 {
 	int r; /* next character to be read */

--- a/util.h
+++ b/util.h
@@ -25,6 +25,7 @@
 size_t safe_strcat(char *dst, const char *src, size_t siz);
 uint32_t popcnt(uint32_t v);
 uint32_t count_trailing_zero_bits(uint32_t v);
+uint32_t bit_scan_reverse(uint64_t v);
 void squeeze(char *str);
 double time_sec(void);
 #ifdef TARGET_OS_WINDOWS


### PR DESCRIPTION
AMD calls these bits `XFeatureSupportedMask`, but Intel doesn't have so snappy a name. Either way, processors may only implement some state indicated by the bits in this mask. Zen 4 processors support AVX 512, and those subleaves, but do not support MPX or IA32_XSS, meaning on those processors leaf D EAX is `0x2e7`. Using popcount here means cpuid stops walking subleaves early and can miss present feature state leaves.

From that same Zen 4 procesor, cpuid misses the ZMM_Hi16 leaf, but all the ZMM registers are implemented here:
```
  Extended state for 256-bit AVX YMM_Hi128 requires 256 bytes, offset 576
  Extended state for 512-bit AVX OpMask requires 64 bytes, offset 832
  Extended state for 512-bit AVX ZMM_Hi256 requires 512 bytes, offset 896
```
Meanwhile with this patch we get both ZMM_Hi16 and MPK:
```
  Extended state for 256-bit AVX YMM_Hi128 requires 256 bytes, offset 576
  Extended state for 512-bit AVX OpMask requires 64 bytes, offset 832
  Extended state for 512-bit AVX ZMM_Hi256 requires 512 bytes, offset 896
  Extended state for 512-bit AVX ZMM_Hi16 requires 1024 bytes, offset 1408
  Extended state for Protected keys requires 8 bytes, offset 2432
```